### PR TITLE
Import from PIL to support pillow

### DIFF
--- a/font-awesome-to-png.py
+++ b/font-awesome-to-png.py
@@ -12,7 +12,7 @@
 
 import sys, argparse
 from os import path, access, R_OK
-import Image, ImageFont, ImageDraw
+from PIL import Image, ImageFont, ImageDraw
 
 # Support Unicode literals with both Python 2 and 3
 if sys.version < '3':


### PR DESCRIPTION
Import Image, ImageFont and ImageDraw "from PIL" to support pillow, the alternative PIL distribution.
