### PR TITLE
add "cog" and "cogs" icons

### DIFF
--- a/font-awesome-to-png.py
+++ b/font-awesome-to-png.py
@@ -111,6 +111,8 @@ icons = {
     "code": u("\uf121"),
     "code-fork": u("\uf126"),
     "coffee": u("\uf0f4"),
+    "cog": u("\uf013"),
+    "cogs": u("\uf085"),
     "columns": u("\uf0db"),
     "comment": u("\uf075"),
     "comment-o": u("\uf0e5"),


### PR DESCRIPTION
The script didn't know of these two icons. Here's the fix.
